### PR TITLE
Python 3.8: upgrade to 3.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ env:
   - NEO4J_VERSION="3.3.3"
   - NEO4J_VERSION="3.4.0"
 install:
-  - sudo apt-get update && sudo apt-get install oracle-java8-installer
+  - sudo add-apt-repository -y ppa:openjdk-r/ppa
+  - sudo apt-get update && sudo apt-get install openjdk-8-jre-headless
   - curl -L http://dist.neo4j.org/neo4j-community-$NEO4J_VERSION-unix.tar.gz | tar xz
 before_script:
-  - JAVA_HOME=/usr/lib/jvm/java-8-oracle neo4j-community-$NEO4J_VERSION/bin/neo4j start
+  - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 neo4j-community-$NEO4J_VERSION/bin/neo4j start
   - sleep 10
 script: "python setup.py test"

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 Version 3.3.2 [Work in progress - date not finalised yet]
+* Minor revisions in `test_set_connection`, `spatial datatypes` and documentation (#442, #446, #447) - Athanasios Anastasiou
+* Added `max_length` constraint on `StringProperty` (#445) - Lazy-Y
 * Upgraded neo4j python driver requirement to 1.7.2 (#432) - Robert Grant
 * Added a `DateTimeFormatProperty` (#428) - Yu Shengnan
 * Updated `setup.py` so that it excludes the `test/` and `test/test_contrib/` sub-packages (#426) - Jorge Valhondo Rama

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,4 @@
-Version 3.3.2 [Work in progress - date not finalised yet]
+Version 3.3.2 2019-09-29
 * Fixed validation for unique properties to also be optional (#470) - Jon Daly
 * Fixed tests-with-docker-compose.sh (#452) - Jorge Valhondo Rama
 * Added exclusion example to documentation and improved naming consistency (#456, #466) - Elena Williams 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,17 @@
+Version 3.3.1 2019-02-08
+ * Fixed a number of warnings due to deprecations both within neomodel and pytest and overall improvements in
+   code style (#381) - Abhishek Modi
+ * Added support for spatial data through neomodel.contrib.spatial_datatypes (#384) - Athanasios Anastasiou
+ * Added the ability to filter "left-hand statements" (in NodeSet expressions) too (#395) - Grzegorz Grzywacz
+ * Refactor the Node Class Registry to make util.Database a true Singleton (#403) - Giorgos Oikonomou
+     * Many thanks to Giorgos Oikonomou, Jon Daly, Adam Romano, Andrew Tergis, Mato Žgajner, Mostafa Moradian, mjmare,
+       Phoebe Bright, Robert Grant, jberends and anyone else who helped flag, track and correct this bug. For more
+       information, please see: https://github.com/neo4j-contrib/neomodel/issues/378
+     * Added the ClassAlreadyDefined exception to prevent against accidental redefinitions of data model classes (#409)
+       - Athanasios Anastasiou
+ * Added the ability to lazily `.nodes.get()` and `.nodes.all()` (#406) - Matan Hart
+ * Fixed a bug in the assumed direction of relationships in _build_merge_query (#408) - MrAnde7son
+
 Version 3.3.0 2018-10-04
  * Added support for Q() in filter and exclude (#360) - Juan H. Hidalgo
  * Added  object docs and examples - Juan H. Hidalgo

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+Version 3.3.2 [Work in progress - date not finalised yet]
+* Upgraded neo4j python driver requirement to 1.7.2 (#432) - Robert Grant
+* Added a `DateTimeFormatProperty` (#428) - Yu Shengnan
+* Updated `setup.py` so that it excludes the `test/` and `test/test_contrib/` sub-packages (#426) - Jorge Valhondo Rama
+* Updated getting_started.rst typo (#419) - fredthehead
+* Fixed NeomodelPoint instantiation bug (#418) - Athanasios Anastasiou
+
 Version 3.3.1 2019-02-08
  * Fixed a number of warnings due to deprecations both within neomodel and pytest and overall improvements in
    code style (#381) - Abhishek Modi

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,8 @@
 Version 3.3.2 [Work in progress - date not finalised yet]
+* Fixed validation for unique properties to also be optional (#470) - Jon Daly
+* Fixed tests-with-docker-compose.sh (#452) - Jorge Valhondo Rama
+* Added exclusion example to documentation and improved naming consistency (#456, #466) - Elena Williams 
+* Fixed the Travis-CI build problems by switching to openjdk (#471) - Duncan Booth
 * Minor revisions in `test_set_connection`, `spatial datatypes` and documentation (#442, #446, #447) - Athanasios Anastasiou
 * Added `max_length` constraint on `StringProperty` (#445) - Lazy-Y
 * Upgraded neo4j python driver requirement to 1.7.2 (#432) - Robert Grant

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,6 @@ An Object Graph Mapper (OGM) for the neo4j_ graph database, built on the awesome
     :target: https://neomodel.readthedocs.io/en/latest/?badge=latest
 
 
-! Support for Python 2.7 !
-==========================
-**Please note:** Version 3.3.1 will be the last version that `neomodel` provides suppport for Python 2.7. By its
-next major release, the project will focus solely on Python 3.*.
-
-
 Documentation
 =============
 
@@ -71,7 +65,7 @@ Contributing
 Ideas, bugs, tests and pull requests always welcome. 
 
 As of release `3.3.2` we now have a curated list of issues / development targets for
-`neomodel` available on [the Wiki](https://github.com/neo4j-contrib/neomodel/wiki/TODOs-&-Enhancements).
+`neomodel` available on `the Wiki <https://github.com/neo4j-contrib/neomodel/wiki/TODOs-&-Enhancements>`_.
 
 If you are interested in developing `neomodel` further, pick a subject from the list and open a Pull Request (PR) for 
 it. If you are adding a feature that is not captured in that list yet, consider if the work for it could also 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,14 @@ Upgrading 2.x to 3.x
 Contributing
 ============
 
-Ideas, bugs, tests and pull requests always welcome.
+Ideas, bugs, tests and pull requests always welcome. 
+
+As of release `3.3.2` we now have a curated list of issues / development targets for
+`neomodel` available on [the Wiki](https://github.com/neo4j-contrib/neomodel/wiki/TODOs-&-Enhancements).
+
+If you are interested in developing `neomodel` further, pick a subject from the list and open a Pull Request (PR) for 
+it. If you are adding a feature that is not captured in that list yet, consider if the work for it could also 
+contribute towards delivering any of the existing todo items too.
 
 Running the test suite
 ----------------------

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -164,6 +164,9 @@ Working with relationships::
     # Find people called 'Jim' in germany
     germany.inhabitant.search(name='Jim')
 
+    # Find all the people called in germany except 'Jim'
+    germany.inhabitant.exclude(name='Jim')
+
     # Remove Jim's country relationship with Germany
     jim.country.disconnect(germany)
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -5,15 +5,15 @@ Getting started
 Connecting
 ==========
 
-Before executing any neomodel code set the connection url::
+Before executing any neomodel code, set the connection url::
 
     from neomodel import config
     config.DATABASE_URL = 'bolt://neo4j:neo4j@localhost:7687'  # default
 
-This needs to be called early on in your app, if you are using Django the `settings.py` file is ideal.
+This must be called early on in your app, if you are using Django the `settings.py` file is ideal.
 
 If you are using your neo4j server for the first time you will need to change the default password.
-This can be achieved by visiting the neo4j admin panel (default: http://localhost:7474 ).
+This can be achieved by visiting the neo4j admin panel (default: ``http://localhost:7474`` ).
 
 You can also change the connection url at any time by calling ``set_connection``::
 
@@ -22,22 +22,44 @@ You can also change the connection url at any time by calling ``set_connection``
 
 The new connection url will be applied to the current thread or process.
 
-Definition
-==========
+In general however, it is better to `avoid setting database access credentials in plain sight <https://
+www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf>`_. Neo4J defines a number of
+`environment variables <https://neo4j.com/developer/kb/how-do-i-authenticate-with-cypher-shell-without-specifying-the-
+username-and-password-on-the-command-line/>`_ that are used in its tools and these can be re-used for other applications
+too.
 
-Below is a definition of two types of node `Person` and `Country`::
+These are:
+
+* ``NEO4J_USERNAME``
+* ``NEO4J_PASSWORD``
+* ``NEO4J_BOLT_URL``
+
+By setting these with (for example): ::
+
+    $ export NEO4J_USERNAME=neo4j
+    $ export NEO4J_PASSWORD=neo4j
+    $ export NEO4J_BOLT_URL="bolt://$NEO4J_USERNAME:$NEO4J_PASSWORD@localhost:7687"
+
+They can be accessed from a Python script via the ``environ`` dict of module ``os`` and be used to set the connection
+with something like: ::
+
+    import os
+    from neomodel import config
+
+    config.DATABASE_URL = os.environ["NEO4J_BOLT_URL"]
+
+Defining Node Entities and Relationships
+========================================
+
+Below is a definition of two related nodes `Person` and `Country`: ::
 
     from neomodel import (config, StructuredNode, StringProperty, IntegerProperty,
-        UniqueIdProperty, RelationshipTo, RelationshipFrom)
+        UniqueIdProperty, RelationshipTo)
 
     config.DATABASE_URL = 'bolt://neo4j:password@localhost:7687'
 
     class Country(StructuredNode):
         code = StringProperty(unique_index=True, required=True)
-
-        # traverse incoming IS_FROM relation, inflate to Person objects
-        inhabitant = RelationshipFrom('Person', 'IS_FROM')
-
 
     class Person(StructuredNode):
         uid = UniqueIdProperty()
@@ -47,44 +69,50 @@ Below is a definition of two types of node `Person` and `Country`::
         # traverse outgoing IS_FROM relations, inflate to Country objects
         country = RelationshipTo(Country, 'IS_FROM')
 
+Nodes are defined in the same way classes are defined in Python with the only difference that data members of those
+classes that are intended to be stored to the database must be defined as ``neomodel`` property objects. For more
+detailed information on property objects please see the section on :ref:`property_types`.
 
-There is one type of relationship present ``IS_FROM``, we are defining two different ways for traversing it
-one accessible via ``Person`` objects and one via ``Country`` objects
+Relationships are defined via ``Relationship, RelationshipTo, RelationshipFrom`` objects. ``RelationshipTo,
+RelationshipFrom`` can also specify the direction that a relationship would be allowed to be traversed. In this
+particular example, ``Country`` objects would be accessible by ``Person`` objects but not the other way around.
 
-We can use the ``Relationship`` class as opposed to the ``RelationshipTo`` or ``RelationshipFrom``
-if we don't want to specify a direction.
+When the relationship can be bi-directional, please avoid establishing two complementary ``RelationshipTo,
+RelationshipFrom`` relationships and use ``Relationship``, on one of the class definitions instead. In all of these
+cases, navigability matters more to the model as defined in Python. A relationship will be established in Neo4J but
+in the case of ``Relationship`` it will be possible to be queried in either direction.
 
-Neomodel automatically creates a label for each ``StructuredNode`` class in the database
-with the corresponding indexes and constraints.
+Neomodel automatically creates a label for each ``StructuredNode`` class in the database with the corresponding indexes
+and constraints.
 
-Setup constraints and indexes
-=============================
-After creating node definitions in python, any constraints or indexes need to be added to Neo4j.
-
-Neomodel provides a script to automate this::
+Applying constraints and indexes
+================================
+After creating a model in Python, any constraints or indexes need must be applied to Neo4j and ``neomodel`` provides a
+script to automate this: ::
 
     $ neomodel_install_labels yourapp.py someapp.models --db bolt://neo4j:neo4j@localhost:7687
 
-It is important to execute this after altering the schema. Keep an eye on the number of classes it detects each time.
+It is important to execute this after altering the schema and observe the number of classes it reports.
 
 Remove existing constraints and indexes
 =======================================
-For deleting all existing constraints and indexes from database, neomodel provides a script to automate this::
+Similarly, ``neomodel`` provides a script to automate the removal of all existing constraints and indexes from
+the database, when this is required: ::
 
     $ neomodel_remove_labels --db bolt://neo4j:neo4j@localhost:7687
 
-After executing, it will print all indexes and constraints it has deleted.
+After executing, it will print all indexes and constraints it has removed.
 
-Create, Update, Delete
-======================
+Create, Update, Delete operations
+=================================
 
 Using convenience methods such as::
 
-    jim = Person(name='Jim', age=3).save()
+    jim = Person(name='Jim', age=3).save() # Create
     jim.age = 4
-    jim.save() # validation happens here
+    jim.save() # Update, (with validation)
     jim.delete()
-    jim.refresh() # reload properties from neo
+    jim.refresh() # reload properties from the database
     jim.id # neo4j internal id
 
 Retrieving nodes
@@ -95,7 +123,7 @@ Using the ``.nodes`` class property::
     # Return all nodes
     all_nodes = Person.nodes.all()
 
-    # Returns Person by Person.name=='Jim' or raises Person.DoesNotExist if no match
+    # Returns Person by Person.name=='Jim' or raises neomodel.DoesNotExist if no match
     jim = Person.nodes.get(name='Jim')
 
 
@@ -105,7 +133,7 @@ simply returning the node IDs rather than every attribute associated with that N
     # Will return None unless "bob" exists
     someone = Person.nodes.get_or_none(name='bob')
 
-    # Will return the first Person node with the name bob. This raises Person.DoesNotExist if there's no match.
+    # Will return the first Person node with the name bob. This raises neomodel.DoesNotExist if there's no match.
     someone = Person.nodes.first(name='bob')
 
     # Will return the first Person node with the name bob or None if there's no match

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -73,6 +73,9 @@ Nodes are defined in the same way classes are defined in Python with the only di
 classes that are intended to be stored to the database must be defined as ``neomodel`` property objects. For more
 detailed information on property objects please see the section on :ref:`property_types`.
 
+**If** you have a need to attach "ad-hoc" properties to nodes that have not been specified at its definition, then 
+consider deriving from the :ref:`semistructurednode_doc` class.
+
 Relationships are defined via ``Relationship, RelationshipTo, RelationshipFrom`` objects. ``RelationshipTo,
 RelationshipFrom`` can also specify the direction that a relationship would be allowed to be traversed. In this
 particular example, ``Country`` objects would be accessible by ``Person`` objects but not the other way around.

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -125,7 +125,7 @@ Working with relationships::
     if jim.country.is_connected(germany):
         print("Jim's from Germany")
 
-    for p in germany.inhabitant.all()
+    for p in germany.inhabitant.all():
         print(p.name) # Jim
 
     len(germany.inhabitant) # 1

--- a/doc/source/module_documentation.rst
+++ b/doc/source/module_documentation.rst
@@ -14,6 +14,12 @@ Core
 .. automodule:: neomodel.core
   :members:
 
+.. _semistructurednode_doc:
+
+``SemiStructuredNode``
+^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: neomodel.contrib.SemiStructuredNode
+
 Properties
 ----------
 .. automodule:: neomodel.properties

--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -123,11 +123,11 @@ Neomodel provides the `UniqueIdProperty` to generate unique identifiers for node
 Dates and times
 ===============
 
-The *DateTimeProperty* accepts `datetime.datetime` objects of any timezone and stores them as a UTC epoch value.
+The *DateTimeProperty* accepts ``datetime.datetime`` objects of any timezone and stores them as a UTC epoch value.
 These epoch values are inflated to datetime.datetime objects with the UTC timezone set.
 
-The *DateTimeFormatProperty* accepts `datetime.datetime` objects which are same as *DateTimeProperty* but stores them
-as a formatted date string. The date formatted pattern should be set by argument, default is "%Y-%m-%d".
+Similarly, the *DateTimeFormatProperty* accepts ``datetime.datetime`` objects but stores them
+as a user defined formatted date string. The pattern is set by the ``format`` argument which defaults to "%Y-%m-%d".
 
 In the following example the datetime will be stored as 'YYYY-MM-DD HH:mm:ss'::
       
@@ -135,11 +135,12 @@ In the following example the datetime will be stored as 'YYYY-MM-DD HH:mm:ss'::
 
 The *DateProperty* accepts datetime.date objects which are stored as a string property 'YYYY-MM-DD'.
 
-The `default_now` parameter specifies the current time as the default value::
+In all of the above, the `default_now` parameter specifies the "current time" (the time a "write" operation takes place)
+as the default value::
 
         created = DateTimeProperty(default_now=True)
 
-Enforcing a specific timezone is done by setting the config variable` NEOMODEL_FORCE_TIMEZONE=1`.
+Enforcing a specific timezone is done by setting the config variable ``NEOMODEL_FORCE_TIMEZONE=1``.
 
 
 Other properties
@@ -188,15 +189,11 @@ This section groups together special notes for specific data types.
 ``StringProperty``
 ------------------
 
-Perhaps the most obvious constraint for a String property is its length. There are two notes related to a string's
-length:
-
-1. A maximum length constraint would impose a performance penalty.
-2. One needs to be extremely careful with very long strings that are also indexed.
+1. One needs to be extremely careful with very long strings that are also indexed.
     1. Neo4j imposes an internal hard limit of 4039 **bytes** to properties of type string. This is **not the same** as
        the length of a UTF-8 string **in characters**, because each character in a UTF-8 string might be represented
        by more than one bytes.
-    2. Internally, Neo4j will **truncate** a string so that its **byte** length is no longer than 4039 but it will not
+    2. Internally, Neo4j will **truncate** a string so that its **byte** length is not longer than 4039 but it will not
        raise an exception. Consequently, if a `neomodel.StringProperty()` happens to run much longer than this limit,
        it will be silently truncated. The rest of the string will be dropped and the next time the entity is read from
        the database it will appear to be incomplete.

--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -1,3 +1,5 @@
+.. _property_types:
+
 ==============
 Property types
 ==============
@@ -8,11 +10,24 @@ The following properties are available on nodes and relationships:
 :class:`~neomodel.properties.AliasProperty`           :class:`~neomodel.properties.IntegerProperty`
 :class:`~neomodel.properties.ArrayProperty`           :class:`~neomodel.properties.JSONProperty`
 :class:`~neomodel.properties.BooleanProperty`         :class:`~neomodel.properties.RegexProperty`
-:class:`~neomodel.properties.DateProperty`            :class:`~neomodel.properties.StringProperty`
+:class:`~neomodel.properties.DateProperty`            :class:`~neomodel.properties.StringProperty` (`Notes <http://www.google.com>`_)
 :class:`~neomodel.properties.DateTimeProperty`        :class:`~neomodel.properties.UniqueIdProperty`
 :class:`~neomodel.properties.DateTimeFormatProperty`  :class:`~neomodel.contrib.spatial_properties.PointProperty`
 :class:`~neomodel.properties.FloatProperty`           \
 ====================================================  ===========================================================
+
+
+Naming Convention
+=================
+You can follow standard
+`Python variable naming conventions <https://www.python.org/dev/peps/pep-0008/#function-and-variable-names>`_ to name
+an entity's properties but please note that **a property name should not begin with an underscore (_) character**.
+
+Doing so leads to `unpredictable results <https://github.com/neo4j-contrib/neomodel/issues/279#issue-267468010>`_.
+
+By design, ``neomodel.StructuredNode`` derived entities reserve a number of *protected* variables to perform quick
+look-up operations. The names of those variables begin with an underscore and therefore any member variable that
+begins with this character is excluded from further processing.
 
 
 Defaults
@@ -27,6 +42,44 @@ Default values can be specified for any property, even as the result of a
 And in terms of a :term:`function` or :term:`lambda`::
 
         my_datetime = DateTimeProperty(default=lambda: datetime.now(pytz.utc))
+
+Mandatory / Optional Properties
+===============================
+Whether the value of a property is absolutely essential for an entity's existence or can be left undefined is determined
+by the ``required`` parameter that applies to all properties.
+
+This is a boolean parameter that defaults to ``False`` and makes an entity's properties *optional* by default.
+
+Setting ``required=True`` makes the property mandatory. Mandatory properties cannot have default values and setting
+both ``required=True, default`` will result in a ``ValueError`` exception.
+
+It is worth noting here that ``required=False`` means that the property's value can also be ``None`` **in addition** to
+a valid valud. A value of ``None`` is **different** than a value of ``""`` and this can sometimes lead to logical
+errors.
+
+For example::
+
+    class Person(StructuredNode):
+        uid = UniqueIdProperty()
+        full_name = StringProperty(required = True)
+        email = EmailProperty()
+
+Here ``Person.full_name`` is mandatory but ``Person.email`` is optional. With this definition, the following would
+fail::
+
+    some_person = Person().save()
+
+Because ``full_name == None`` but ``full_name`` has been marked as ``required`` for the definition of ``Person``.
+
+Notice here that the following would fail too::
+
+    some_person = Person(full_name="Thomas Edison", email="").save()
+
+In this case the ``EmailProperty`` would raise a ``ValueError`` to complain that ``""`` does not look like a valid email
+address.
+
+The ``email`` property **is** optional here which means that its value can be left undefined (``None``), **not** that
+its set of valid values includes the empty string.
 
 Choices
 =======
@@ -46,8 +99,8 @@ The value's validity will be checked both when saved and loaded from the databas
 
 Array Properties
 ================
-Neomodel supports arrays via the `ArrayProperty` class and a list element type 
-can optionally be provided as the first argument::
+Neomodel supports neo4j's arrays via the `ArrayProperty` class and the class for each list element can optionally be
+provided as the first argument::
    
     class Person(StructuredNode):
         names = ArrayProperty(StringProperty(), required=True)
@@ -73,12 +126,12 @@ Dates and times
 The *DateTimeProperty* accepts `datetime.datetime` objects of any timezone and stores them as a UTC epoch value.
 These epoch values are inflated to datetime.datetime objects with the UTC timezone set.
 
-The *DateTimeFormatProperty* accepts `datetime.datetime` objects which are same as *DateTimeProperty* but stores them as a formatted date string.
-The date formatted pattern should be set by argument, default is "%Y-%m-%d".
+The *DateTimeFormatProperty* accepts `datetime.datetime` objects which are same as *DateTimeProperty* but stores them
+as a formatted date string. The date formatted pattern should be set by argument, default is "%Y-%m-%d".
+
 In the following example the datetime will be stored as 'YYYY-MM-DD HH:mm:ss'::
       
         created = DateTimeFormatProperty(format="%Y-%m-%d %H:%M:%S")
-
 
 The *DateProperty* accepts datetime.date objects which are stored as a string property 'YYYY-MM-DD'.
 
@@ -125,3 +178,27 @@ This is useful when hiding graph properties behind a python property::
         def name(self, value):
             self.name_ = value
 
+
+Notes
+=====
+
+This section groups together special notes for specific data types.
+
+
+``StringProperty``
+------------------
+
+Perhaps the most obvious constraint for a String property is its length. There are two notes related to a string's
+length:
+
+1. A maximum length constraint would impose a performance penalty.
+2. One needs to be extremely careful with very long strings that are also indexed.
+    1. Neo4j imposes an internal hard limit of 4039 **bytes** to properties of type string. This is **not the same** as
+       the length of a UTF-8 string **in characters**, because each character in a UTF-8 string might be represented
+       by more than one bytes.
+    2. Internally, Neo4j will **truncate** a string so that its **byte** length is no longer than 4039 but it will not
+       raise an exception. Consequently, if a `neomodel.StringProperty()` happens to run much longer than this limit,
+       it will be silently truncated. The rest of the string will be dropped and the next time the entity is read from
+       the database it will appear to be incomplete.
+    3. This can also lead to a `UniqueException` if two strings differ **after** the 4039 byte mark.
+    4. For more information please see `here <https://github.com/neo4j/neo4j/issues/12076#issuecomment-438286444>`_.

--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -4,14 +4,15 @@ Property types
 
 The following properties are available on nodes and relationships:
 
-==============================================  ===========================================================
-:class:`~neomodel.properties.AliasProperty`     :class:`~neomodel.properties.IntegerProperty`
-:class:`~neomodel.properties.ArrayProperty`     :class:`~neomodel.properties.JSONProperty`
-:class:`~neomodel.properties.BooleanProperty`   :class:`~neomodel.properties.RegexProperty`
-:class:`~neomodel.properties.DateProperty`      :class:`~neomodel.properties.StringProperty`
-:class:`~neomodel.properties.DateTimeProperty`  :class:`~neomodel.properties.UniqueIdProperty`
-:class:`~neomodel.properties.FloatProperty`     :class:`~neomodel.contrib.spatial_properties.PointProperty`
-==============================================  ===========================================================
+====================================================  ===========================================================
+:class:`~neomodel.properties.AliasProperty`           :class:`~neomodel.properties.IntegerProperty`
+:class:`~neomodel.properties.ArrayProperty`           :class:`~neomodel.properties.JSONProperty`
+:class:`~neomodel.properties.BooleanProperty`         :class:`~neomodel.properties.RegexProperty`
+:class:`~neomodel.properties.DateProperty`            :class:`~neomodel.properties.StringProperty`
+:class:`~neomodel.properties.DateTimeProperty`        :class:`~neomodel.properties.UniqueIdProperty`
+:class:`~neomodel.properties.DateTimeFormatProperty`  :class:`~neomodel.contrib.spatial_properties.PointProperty`
+:class:`~neomodel.properties.FloatProperty`           \
+====================================================  ===========================================================
 
 
 Defaults
@@ -47,9 +48,7 @@ Array Properties
 ================
 Neomodel supports arrays via the `ArrayProperty` class and a list element type 
 can optionally be provided as the first argument::
-
-    class Person(StructuredNode):
-        names = ArrayProperty(StringProperty(), required=True)
+class Person(StructuredNode): names = ArrayProperty(StringProperty(), required=True)
 
     bob = Person(names=['bob', 'rob', 'robert']).save()
 
@@ -72,6 +71,13 @@ Dates and times
 The *DateTimeProperty* accepts `datetime.datetime` objects of any timezone and stores them as a UTC epoch value.
 These epoch values are inflated to datetime.datetime objects with the UTC timezone set.
 
+The *DateTimeFormatProperty* accepts `datetime.datetime` objects which are same as *DateTimeProperty* but stores them as a formatted date string.
+The date formatted pattern should be set by argument, default is "%Y-%m-%d".
+In the following example the datetime will be stored as 'YYYY-MM-DD HH:mm:ss'::
+      
+        created = DateTimeFormatProperty(format="%Y-%m-%d %H:%M:%S")
+
+
 The *DateProperty* accepts datetime.date objects which are stored as a string property 'YYYY-MM-DD'.
 
 The `default_now` parameter specifies the current time as the default value::
@@ -79,6 +85,7 @@ The `default_now` parameter specifies the current time as the default value::
         created = DateTimeProperty(default_now=True)
 
 Enforcing a specific timezone is done by setting the config variable` NEOMODEL_FORCE_TIMEZONE=1`.
+
 
 Other properties
 ================

--- a/doc/source/properties.rst
+++ b/doc/source/properties.rst
@@ -48,7 +48,9 @@ Array Properties
 ================
 Neomodel supports arrays via the `ArrayProperty` class and a list element type 
 can optionally be provided as the first argument::
-class Person(StructuredNode): names = ArrayProperty(StringProperty(), required=True)
+   
+    class Person(StructuredNode):
+        names = ArrayProperty(StringProperty(), required=True)
 
     bob = Person(names=['bob', 'rob', 'robert']).save()
 

--- a/neomodel/__init__.py
+++ b/neomodel/__init__.py
@@ -12,9 +12,11 @@ from neomodel.relationship_manager import (
 from .relationship import StructuredRel
 from .cardinality import (ZeroOrMore, OneOrMore, ZeroOrOne, One)
 from .properties import (StringProperty, IntegerProperty, AliasProperty,
-                         FloatProperty, BooleanProperty, DateTimeProperty, DateProperty,
-                         NormalizedProperty, RegexProperty, EmailProperty,
-                         JSONProperty, ArrayProperty, UniqueIdProperty)
+                         FloatProperty, BooleanProperty, 
+                         DateTimeFormatProperty, DateTimeProperty,
+                         DateProperty, NormalizedProperty, RegexProperty,
+                         EmailProperty, JSONProperty, ArrayProperty,
+                         UniqueIdProperty)
 
 __author__ = 'Robin Edwards'
 __email__ = 'robin.ge@gmail.com'

--- a/neomodel/contrib/spatial_properties.py
+++ b/neomodel/contrib/spatial_properties.py
@@ -227,6 +227,15 @@ class NeomodelPoint(ShapelyPoint):
             raise AttributeError('Invalid coordinate ("height") for points defined over {}'.format(self.crs))
         return super(NeomodelPoint, self).z
 
+    # The following operations are necessary here due to the way queries (and more importantly their parameters) get
+    # combined and evaluated in neomodel. Specifically, query expressions get duplicated with deep copies and any valid
+    # datatype values should also implement these operations.
+    def __copy__(self):
+        return NeomodelPoint(self)
+
+    def __deepcopy__(self, memo):
+        return NeomodelPoint(self)
+
 
 class PointProperty(Property):
     """

--- a/neomodel/contrib/spatial_properties.py
+++ b/neomodel/contrib/spatial_properties.py
@@ -22,6 +22,7 @@
 __author__ = "Athanasios Anastasiou"
 
 import neo4j.v1
+import neo4j.types.spatial
 
 # If shapely is not installed, its import will fail and the spatial properties will not be available
 try:
@@ -275,7 +276,7 @@ class PointProperty(Property):
         :type value: Neo4J POINT
         :return: NeomodelPoint
         """
-        if not isinstance(value,neo4j.v1.spatial.Point):
+        if not isinstance(value,neo4j.types.spatial.Point):
             raise TypeError('Invalid datatype to inflate. Expected POINT datatype, received {}'.format(type(value)))
 
         try:
@@ -318,10 +319,10 @@ class PointProperty(Property):
                              'received NeomodelPoint defined over {}'.format(self._crs, value.crs))
 
         if value.crs == 'cartesian-3d':
-            return neo4j.v1.spatial.CartesianPoint((value.x, value.y,  value.z))
+            return neo4j.types.spatial.CartesianPoint((value.x, value.y,  value.z))
         elif value.crs == 'cartesian':
-            return neo4j.v1.spatial.CartesianPoint((value.x,value.y))
+            return neo4j.types.spatial.CartesianPoint((value.x,value.y))
         elif value.crs == 'wgs-84':
-            return neo4j.v1.spatial.WGS84Point((value.longitude, value.latitude))
+            return neo4j.types.spatial.WGS84Point((value.longitude, value.latitude))
         elif value.crs == 'wgs-84-3d':
-            return neo4j.v1.spatial.WGS84Point((value.longitude, value.latitude, value.height))
+            return neo4j.types.spatial.WGS84Point((value.longitude, value.latitude, value.height))

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -405,13 +405,14 @@ class StructuredNode(NodeBase):
     @classmethod
     def get_or_create(cls, *props, **kwargs):
         """
-        Call to MERGE with parameters map. A new instance will be created and saved if does not already exists,
+        Call to MERGE with parameters map. A new instance will be created and saved if does not already exist,
         this is an atomic operation.
         Parameters must contain all required properties, any non required properties with defaults will be generated.
 
         Note that the post_create hook isn't called after get_or_create
 
-        :param props: dict of properties to get or create the entities with.
+        :param props: Arguments to get_or_create as tuple of dict with property names and values to get or create
+                      the entities with.
         :type props: tuple
         :param relationship: Optional, relationship to get/create on when new entity is created.
         :param lazy: False by default, specify True to get nodes with id only without the parameters.

--- a/neomodel/core.py
+++ b/neomodel/core.py
@@ -114,8 +114,8 @@ def install_all_labels(stdout=None):
     if not stdout:
         stdout = sys.stdout
 
-    def subsub(kls):  # recursively return all subclasses
-        return kls.__subclasses__() + [g for s in kls.__subclasses__() for g in subsub(s)]
+    def subsub(cls):  # recursively return all subclasses
+        return cls.__subclasses__() + [g for s in cls.__subclasses__() for g in subsub(s)]
 
     stdout.write("Setting up indexes and constraints...\n\n")
 

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -433,6 +433,39 @@ class DateProperty(Property):
             raise ValueError(msg)
         return value.isoformat()
 
+class DateTimeFormatProperty(Property):
+    """
+    Store a datetime by custome format
+    :param default_now: If ``True``, the creation time (Local) will be used as default.
+                        Defaults to ``False``.
+    :param format:      Date format string, default is %Y-%m-%d
+
+    :type default_now:  :class:`bool`
+    :type format:       :class:`str`
+    """
+    form_field_class = 'DateFormatField'
+
+    def __init__(self, default_now=False, format="%Y-%m-%d", **kwargs):
+        if default_now:
+            if 'default' in kwargs:
+                raise ValueError('too many defaults')
+            kwargs['default'] = lambda: datetime.now()
+
+        self.format = format
+        super(DateTimeFormatProperty, self).__init__(**kwargs)
+
+    @validator
+    def inflate(self, value):
+        return datetime.strptime(unicode(value), self.format).date()
+
+    @validator
+    def deflate(self, value):
+        if not isinstance(value, datetime):
+            raise ValueError('datetime object expected, got {0}.'.format(type(value)))
+        return datetime.strftime(value, self.format)
+
+
+
 
 class DateTimeProperty(Property):
     """ A property representing a :class:`datetime.datetime` object as

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -216,7 +216,7 @@ class NormalizedProperty(Property):
         raise NotImplementedError('Specialize normalize method')
 
 
-## TODO remove this with the next major release
+# TODO remove this with the next major release
 def _warn_NormalProperty_renamed():
     warnings.warn(
         'The class NormalProperty was renamed to NormalizedProperty. '
@@ -226,10 +226,12 @@ def _warn_NormalProperty_renamed():
 
 if sys.version_info >= (3, 6):
     class NormalProperty(NormalizedProperty):
+
         def __init_subclass__(cls, **kwargs):
             _warn_NormalProperty_renamed()
 else:
     class NormalProperty(NormalizedProperty):
+
         def __init__(self, *args, **kwargs):
             _warn_NormalProperty_renamed()
             super(NormalProperty, self).__init__(*args, **kwargs)
@@ -289,9 +291,11 @@ class StringProperty(NormalizedProperty):
                     value ``None`` is used, any string is valid.
     :type choices: Any type that can be used to initiate a :class:`dict`.
     """
-    def __init__(self, choices=None, **kwargs):
+
+    def __init__(self, choices=None, max_length=None, **kwargs):
         super(StringProperty, self).__init__(**kwargs)
 
+        self.max_length = max_length
         if choices is None:
             self.choices = None
         else:
@@ -309,6 +313,8 @@ class StringProperty(NormalizedProperty):
     def normalize(self, value):
         if self.choices is not None and value not in self.choices:
             raise ValueError("Invalid choice: {}".format(value))
+        if self.max_length is not None and len(value) > self.max_length:
+            raise ValueError("Max Length Exceeds: {}".format(value))
         return unicode(value)
 
     def default_value(self):
@@ -482,6 +488,7 @@ class JSONProperty(Property):
 
     The structure will be inflated when a node is retrieved.
     """
+
     def __init__(self, *args, **kwargs):
         super(JSONProperty, self).__init__(*args, **kwargs)
 
@@ -498,6 +505,7 @@ class AliasProperty(property, Property):
     """
     Alias another existing property
     """
+
     def __init__(self, to=None):
         """
         Create new alias
@@ -531,6 +539,7 @@ class UniqueIdProperty(Property):
     """
     A unique identifier, a randomly generated uid (uuid4) with a unique index
     """
+
     def __init__(self, **kwargs):
         for item in ['required', 'unique_index', 'index', 'default']:
             if item in kwargs:

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -443,7 +443,7 @@ class DateTimeFormatProperty(Property):
     :type default_now:  :class:`bool`
     :type format:       :class:`str`
     """
-    form_field_class = 'DateFormatField'
+    form_field_class = 'DateTimeFormatField'
 
     def __init__(self, default_now=False, format="%Y-%m-%d", **kwargs):
         if default_now:
@@ -456,7 +456,7 @@ class DateTimeFormatProperty(Property):
 
     @validator
     def inflate(self, value):
-        return datetime.strptime(unicode(value), self.format).date()
+        return datetime.strptime(unicode(value), self.format)
 
     @validator
     def deflate(self, value):

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -295,11 +295,11 @@ class StringProperty(NormalizedProperty):
     """
 
     def __init__(self, choices=None, max_length=None, **kwargs):
-        if max_length is not None and choices is not None:
-            raise ValueError("The arguments `choices` and `max_length` are mutually exclusive.")
-            
-        if max_length<1:
-            raise ValueError("`max_length` cannot be zero or take negative values.")
+        if max_length is not None:
+            if choices is not None:
+                raise ValueError("The arguments `choices` and `max_length` are mutually exclusive.")
+            if max_length<1:
+                raise ValueError("`max_length` cannot be zero or take negative values.")
 
         super(StringProperty, self).__init__(**kwargs)
 

--- a/neomodel/properties.py
+++ b/neomodel/properties.py
@@ -86,7 +86,7 @@ class PropertyManager(object):
                 deflated[db_property] = property.deflate(
                     property.default_value(), obj
                 )
-            elif property.required or property.unique_index:
+            elif property.required:
                 raise RequiredProperty(name, cls)
             elif not skip_empty:
                 deflated[db_property] = None

--- a/neomodel/util.py
+++ b/neomodel/util.py
@@ -5,7 +5,8 @@ import time
 import warnings
 from threading import local
 
-from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError, Node
+from neo4j.v1 import GraphDatabase, basic_auth, CypherError, SessionError
+from neo4j.types.graph import Node
 
 from . import config
 from .exceptions import UniqueProperty, ConstraintValidationFailed,  ModelDefinitionMismatch

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = test --strict
+addopts = test --strict --resetdb
 
 [aliases]
 test = pytest

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='neomodel',
-    version='3.3.0',
+    version='3.3.1',
     description='An object mapper for the neo4j graph database.',
     long_description=open('README.rst').read(),
     author='Robin Edwards',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='neomodel',
-    version='3.3.1',
+    version='4.0.0',
     description='An object mapper for the neo4j graph database.',
     long_description=open('README.rst').read(),
     author='Robin Edwards',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='neomodel',
-    version='4.0.0',
+    version='3.3.2',
     description='An object mapper for the neo4j graph database.',
     long_description=open('README.rst').read(),
     author='Robin Edwards',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     setup_requires=['pytest-runner'] if any(x in ('pytest', 'test') for x in sys.argv) else [],
     tests_require=['pytest', 'shapely'],
-    install_requires=['neo4j-driver>=1.5.2, <1.7.0', 'pytz>=2016.10'],
+    install_requires=['neo4j-driver=1.7.2', 'pytz>=2016.10'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     setup_requires=['pytest-runner'] if any(x in ('pytest', 'test') for x in sys.argv) else [],
     tests_require=['pytest', 'shapely'],
-    install_requires=['neo4j-driver=1.7.2', 'pytz>=2016.10'],
+    install_requires=['neo4j-driver==1.7.2', 'pytz>=2016.10'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=True,
     url='http://github.com/neo4j-contrib/neomodel',
     license='MIT',
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=('test', 'test.*')),
     keywords='graph neo4j ORM OGM',
     scripts=['scripts/neomodel_install_labels', 'scripts/neomodel_remove_labels'],
     setup_requires=['pytest-runner'] if any(x in ('pytest', 'test') for x in sys.argv) else [],

--- a/test/test_contrib/test_spatial_datatypes.py
+++ b/test/test_contrib/test_spatial_datatypes.py
@@ -46,6 +46,7 @@ def check_and_skip_neo4j_least_version(required_least_neo4j_version, message):
             pytest.skip('Neo4j version: {}. {}.'
                         'Skipping test.'.format(os.environ['NEO4J_VERSION'], message))
 
+
 def basic_type_assertions(ground_truth, tested_object, test_description, check_neo4j_points=False):
     """
     Tests that `tested_object` has been created as intended.

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -152,3 +152,24 @@ def test_array_of_points():
     assert retrieved_object.locations == [neomodel.contrib.spatial_properties.NeomodelPoint((0.0,0.0)),
                                           neomodel.contrib.spatial_properties.NeomodelPoint((1.0,0.0))], \
         "Array of Points incorrect values."
+
+def test_simple_storage_retrieval():
+    """
+    Performs a simple Create, Retrieve via .save(), .get() which, due to the way Q objects operate, tests the
+    __copy__, __deepcopy__ operations of NeomodelPoint.
+    :return:
+    """
+
+    class TestStorageRetrievalProperty(neomodel.StructuredNode):
+        uid = neomodel.UniqueIdProperty()
+        description = neomodel.StringProperty()
+        location = neomodel.contrib.spatial_properties.PointProperty(crs="cartesian")
+
+    a_restaurant = TestStorageRetrievalProperty(description="Milliways",
+                                                location=neomodel.contrib.spatial_properties.NeomodelPoint((0,0))
+                                                ).save()
+
+    a_property = TestStorageRetrievalProperty.nodes.get(location=neomodel.contrib.spatial_properties.NeomodelPoint((0,0)))
+
+    assert a_restaurant.description == a_property.description
+

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -114,6 +114,7 @@ def test_default_value():
 
     # Neo4j versions lower than 3.4.0 do not support Point. In that case, skip the test.
     check_and_skip_neo4j_least_version(340, 'This version does not support spatial data types.')
+    
     # Save an object
     an_object = LocalisableEntity().save()
     coords = an_object.location.coords[0]

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -9,6 +9,7 @@ import neomodel
 import neomodel.contrib.spatial_properties
 import pytest
 import neo4j.v1
+import neo4j.types.spatial
 from .test_spatial_datatypes import basic_type_assertions, check_and_skip_neo4j_least_version
 import random
 
@@ -47,13 +48,13 @@ def test_inflate():
     # `basic_type_assertions` and different messages to be able to localise the exception.
     #
     # Array of points to inflate and messages when things go wrong
-    values_from_db = [(neo4j.v1.spatial.CartesianPoint((0.0, 0.0)),
+    values_from_db = [(neo4j.types.spatial.CartesianPoint((0.0, 0.0)),
                        'Expected Neomodel 2d cartesian point when inflating 2d cartesian neo4j point'),
-                      (neo4j.v1.spatial.CartesianPoint((0.0, 0.0, 0.0)),
+                      (neo4j.types.spatial.CartesianPoint((0.0, 0.0, 0.0)),
                        'Expected Neomodel 3d cartesian point when inflating 3d cartesian neo4j point'),
-                      (neo4j.v1.spatial.WGS84Point((0.0, 0.0)),
+                      (neo4j.types.spatial.WGS84Point((0.0, 0.0)),
                        'Expected Neomodel 2d geographical point when inflating 2d geographical neo4j point'),
-                      (neo4j.v1.spatial.WGS84Point((0.0, 0.0, 0.0)),
+                      (neo4j.types.spatial.WGS84Point((0.0, 0.0, 0.0)),
                        'Expected Neomodel 3d geographical point inflating 3d geographical neo4j point')]
 
     # Run the above tests
@@ -89,7 +90,7 @@ def test_deflate():
 
     # Run the above tests.
     for a_value in values_from_neomodel:
-        expected_point = neo4j.v1.spatial.Point(tuple(a_value[0].coords[0]))
+        expected_point = neo4j.types.spatial.Point(tuple(a_value[0].coords[0]))
         expected_point.srid = CRS_TO_SRID[a_value[0].crs]
         deflated_point = neomodel.contrib.spatial_properties.PointProperty(crs=a_value[0].crs).deflate(a_value[0])
         basic_type_assertions(expected_point, deflated_point, '{}, received {}'.format(a_value[1], deflated_point),

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -114,7 +114,6 @@ def test_default_value():
 
     # Neo4j versions lower than 3.4.0 do not support Point. In that case, skip the test.
     check_and_skip_neo4j_least_version(340, 'This version does not support spatial data types.')
-
     # Save an object
     an_object = LocalisableEntity().save()
     coords = an_object.location.coords[0]

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -166,6 +166,9 @@ def test_simple_storage_retrieval():
         description = neomodel.StringProperty()
         location = neomodel.contrib.spatial_properties.PointProperty(crs="cartesian")
 
+    # Neo4j versions lower than 3.4.0 do not support Point. In that case, skip the test.
+    check_and_skip_neo4j_least_version(340, 'This version does not support spatial data types.')
+    
     a_restaurant = TestStorageRetrievalProperty(description="Milliways",
                                                 location=neomodel.contrib.spatial_properties.NeomodelPoint((0,0))
                                                 ).save()

--- a/test/test_contrib/test_spatial_properties.py
+++ b/test/test_contrib/test_spatial_properties.py
@@ -114,7 +114,7 @@ def test_default_value():
 
     # Neo4j versions lower than 3.4.0 do not support Point. In that case, skip the test.
     check_and_skip_neo4j_least_version(340, 'This version does not support spatial data types.')
-    
+
     # Save an object
     an_object = LocalisableEntity().save()
     coords = an_object.location.coords[0]

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -12,10 +12,19 @@ from neomodel.properties import (
 )
 
 
-
-
 class FooBar(object):
     pass
+
+
+def test_string_proerty_max_length_exceeds():
+    class TestLongString(StructuredNode):
+        name = StringProperty(required=True, max_length=5)
+
+    with raises(ValueError):
+        TestLongString(name='a_very_long_name').save()
+
+    node = TestLongString(name='Owen').save()
+    assert 'Owen', node.name
 
 
 def test_string_property_w_choice():
@@ -163,6 +172,7 @@ def test_default_valude_callable_type():
     # check our object gets converted to str without serializing and reload
     def factory():
         class Foo(object):
+
             def __str__(self):
                 return "123"
         return Foo()
@@ -221,6 +231,7 @@ def test_independent_property_name_get_or_create():
 def test_normalized_property(normalized_class):
 
     class TestProperty(normalized_class):
+
         def normalize(self, value):
             self._called_with = value
             self._called = True

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -8,7 +8,7 @@ from neomodel.exceptions import InflateError, DeflateError
 from neomodel.properties import (
     ArrayProperty, IntegerProperty, DateProperty, DateTimeProperty,
     EmailProperty, JSONProperty, NormalProperty, NormalizedProperty,
-    RegexProperty, StringProperty, UniqueIdProperty
+    RegexProperty, StringProperty, UniqueIdProperty, DateTimeFormatProperty
 )
 from neomodel.util import _get_node_properties
 
@@ -78,6 +78,14 @@ def test_date():
     assert prop.deflate(somedate) == '2012-12-15'
     assert prop.inflate('2012-12-15') == somedate
 
+def test_datetime_format():
+    some_format = "%Y-%m-%d %H:%M:%S"
+    prop = DateTimeFormatProperty(format=some_format)
+    prop.name = 'foo'
+    prop.owner = FooBar
+    some_datetime = datetime(2019, 3, 19, 15, 36, 25)
+    assert prop.deflate(some_datetime) == '2019-03-19 15:36:25'
+    assert prop.inflate('2019-03-19 15:36:25') == some_datetime
 
 def test_datetime_exceptions():
     prop = DateTimeProperty()

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -53,8 +53,8 @@ def test_string_property_w_choice():
     except DeflateError as e:
         assert 'choice' in str(e)
     else:
-        assert False, "DeflateError not raised."
-
+        assert False, "DeflateError not raised."        
+    
     node = TestChoices(sex='M').save()
     assert node.get_sex_display() == 'Male'
 

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -16,15 +16,29 @@ class FooBar(object):
     pass
 
 
-def test_string_proerty_max_length_exceeds():
-    class TestLongString(StructuredNode):
-        name = StringProperty(required=True, max_length=5)
-
+def test_string_property_exceeds_max_length():
+    """
+    StringProperty is defined by two properties: `max_length` and `choices` that are mutually exclusive. Furthermore, 
+    max_length must be a positive non-zero number.
+    """
+    # Try to define a property that has both choices and max_length
     with raises(ValueError):
-        TestLongString(name='a_very_long_name').save()
+        some_string_property = StringProperty(choices={"One":"1", "Two":"2"}, max_length=22)
+    
+    # Try to define a string property that has a negative zero length
+    with raises(ValueError):
+        another_string_property = StringProperty(max_length = -35)
+        
+    # Try to validate a long string
+    a_string_property = StringProperty(required=True, max_length=5)
+    with raises(ValueError):
+        a_string_property.normalize('The quick brown fox jumps over the lazy dog')
+        
+    # Try to validate a "valid" string, as per the max_length setting.
+    valid_string = "Owen"
+    normalised_string = a_string_property.normalize(valid_string)
+    assert valid_string == normalised_string, "StringProperty max_length test passed but values do not match."
 
-    node = TestLongString(name='Owen').save()
-    assert 'Owen', node.name
 
 
 def test_string_property_w_choice():

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -4,7 +4,9 @@ from pytest import mark, raises
 from pytz import timezone
 
 from neomodel import StructuredNode, db
-from neomodel.exceptions import InflateError, DeflateError
+from neomodel.exceptions import (
+    InflateError, DeflateError, RequiredProperty, UniqueProperty
+)
 from neomodel.properties import (
     ArrayProperty, IntegerProperty, DateProperty, DateTimeProperty,
     EmailProperty, JSONProperty, NormalProperty, NormalizedProperty,
@@ -373,3 +375,58 @@ def test_indexed_array():
     b = IndexArray(ai=[1, 2]).save()
     c = IndexArray.nodes.get(ai=[1, 2])
     assert b.id == c.id
+
+
+def test_unique_index_prop_not_required():
+    class ConstrainedTestNode(StructuredNode):
+        required_property = StringProperty(required=True)
+        unique_property = StringProperty(unique_index=True)
+        unique_required_property = StringProperty(unique_index=True, required=True)
+        unconstrained_property = StringProperty()
+
+    # Create a node with a missing required property
+    with raises(RequiredProperty):
+        x = ConstrainedTestNode(required_property="required", unique_property="unique")
+        x.save()
+
+    # Create a node with a missing unique (but not required) property.
+    x = ConstrainedTestNode()
+    x.required_property = "required"
+    x.unique_required_property = "unique and required"
+    x.unconstrained_property = "no contraints"
+    x.save()
+
+    # check database property name on low level
+    results, meta = db.cypher_query("MATCH (n:ConstrainedTestNode) RETURN n")
+    node_properties = _get_node_properties(results[0][0])
+    assert node_properties["unique_required_property"] == "unique and required"
+
+    # delete node afterwards
+    x.delete()
+
+
+def test_unique_index_prop_enforced():
+    class UniqueNullableNameNode(StructuredNode):
+        name = StringProperty(unique_index=True)
+
+    # Nameless
+    x = UniqueNullableNameNode()
+    x.save()
+    y = UniqueNullableNameNode()
+    y.save()
+
+    # Named
+    z = UniqueNullableNameNode(name="named")
+    z.save()
+    with raises(UniqueProperty):
+        a = UniqueNullableNameNode(name="named")
+        a.save()
+
+    # Check nodes are in database
+    results, meta = db.cypher_query("MATCH (n:UniqueNullableNameNode) RETURN n")
+    assert len(results) == 3
+
+    # Delete nodes afterwards
+    x.delete()
+    y.delete()
+    z.delete()

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -1,4 +1,4 @@
-from neo4j.addressing import AddressError
+from neobolt.addressing import AddressError
 from pytest import raises
 
 from neomodel import db, StructuredNode, StringProperty, UniqueProperty

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -76,7 +76,7 @@ def test_set_connection_works():
 
     old_url = db.url
     with raises(AddressError):
-        db.set_connection('bolt://user:password@nowhere:7687')
+        db.set_connection('bolt://user:password@6.6.6.6.6.6.6.6:7687')
     db.set_connection(old_url)
     # set connection back
     assert APerson(name='New guy2').save()

--- a/tests-with-docker-compose.sh
+++ b/tests-with-docker-compose.sh
@@ -23,6 +23,7 @@ services:
       - neo4j
     environment:
       NEO4J_BOLT_URL: bolt://neo4j:neo4j@neo4j:7687
+      NEO4J_VERSION: ${NEO4J_VERSION}
   neo4j:
     image: "neo4j:${NEO4J_VERSION}"
     environment:

--- a/tests-with-docker-compose.sh
+++ b/tests-with-docker-compose.sh
@@ -18,7 +18,7 @@ services:
       - .:/src
       - pip-cache:/root/.cache/pip
     working_dir: /src
-    command: sh -c "while ! nc neo4j 7687; do  sleep 1; done; python -B setup.py test"
+    command: sh -c "echo "http://mirror.leaseweb.com/alpine/edge/testing" >> /etc/apk/repositories; apk add --no-cache gcc libc-dev geos-dev; pip install shapely; while ! nc neo4j 7687; do  sleep 1; done; python -B setup.py test"
     links:
       - neo4j
     environment:


### PR DESCRIPTION
Upgrading neomodel to 3.3.2, which uses neo4j driver 1.7.2 which does not break on python 3.8